### PR TITLE
Importing from `#src` were not written by the build

### DIFF
--- a/src/components/SourceLens.gts
+++ b/src/components/SourceLens.gts
@@ -1,12 +1,12 @@
-import { sourceLensModifier } from '#src/lib/modifier.ts';
-import { SourceLensState } from '#src/lib/shared-state.ts';
 import { concat } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { createStore } from 'ember-primitives/store';
-import { getEditorUrl, type EditorType } from '#src/lib/editor-url.ts';
-import { FileSystemBridge } from '#src/lib/file-system-bridge.ts';
+import { getEditorUrl, type EditorType } from '../lib/editor-url.ts';
+import { FileSystemBridge } from '../lib/file-system-bridge.ts';
+import { sourceLensModifier } from '../lib/modifier.ts';
+import { SourceLensState } from '../lib/shared-state.ts';
 import { Editor } from './editor.gts';
 import { EmberLogo, InspectIcon } from './icons.gts';
 import {

--- a/src/components/editor.gts
+++ b/src/components/editor.gts
@@ -3,7 +3,7 @@ import Modifier from 'ember-modifier';
 import type { editor } from 'modern-monaco/editor-core';
 import type { TOC } from '@ember/component/template-only';
 import { assert } from '@ember/debug';
-import type { SourceLensState } from '#src/lib/shared-state.ts';
+import type { SourceLensState } from '../lib/shared-state.ts';
 
 interface MonacoEditorModifierSignature {
   Element: HTMLElement;


### PR DESCRIPTION
Why were these not rewritten when built? @NullVoxPopuli any ideas?